### PR TITLE
fix: return error if problem in normalization

### DIFF
--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -272,7 +272,10 @@ impl<'a> Normalizer<'a> {
                 .find(|(idx, _x)| {
                     loc_range.start >= exon_starts[*idx] && loc_range.start < exon_ends[*idx]
                 })
-                .unwrap()
+                .ok_or(anyhow::anyhow!(
+                    "Cannot find exon for normalization of start of {}",
+                    &var
+                ))?
                 .0;
             let j = exon_starts
                 .iter()
@@ -280,7 +283,10 @@ impl<'a> Normalizer<'a> {
                 .find(|(idx, _x)| {
                     loc_range.end > exon_starts[*idx] && loc_range.end - 1 < exon_ends[*idx]
                 })
-                .unwrap()
+                .ok_or(anyhow::anyhow!(
+                    "Cannot find exon for normalization of end of {}",
+                    &var
+                ))?
                 .0;
 
             if i != j {


### PR DESCRIPTION
Return an error rather than using `unwrap()` if an exon cannot be found for transcript normalization.  This occured for NR_111984.1 on GRCh37 where the first exons are not properly aligned.