### PR TITLE
feat: replacing usages of unwrap() with expect or Result (#70)

### DIFF
--- a/src/data/uta.rs
+++ b/src/data/uta.rs
@@ -215,8 +215,10 @@ impl Provider {
     pub fn with_config(config: &Config) -> Result<Self, anyhow::Error> {
         let config = config.clone();
         let conn = Mutex::new(Client::connect(&config.db_url, NoTls)?);
-        let schema_version =
-            Self::fetch_schema_version(&mut conn.lock().unwrap(), &config.db_schema)?;
+        let schema_version = Self::fetch_schema_version(
+            &mut conn.lock().expect("cannot obtain connection lock"),
+            &config.db_schema,
+        )?;
         Ok(Self {
             config,
             conn,
@@ -262,7 +264,7 @@ impl ProviderInterface for Provider {
         let result: GeneInfoRecord = self
             .conn
             .lock()
-            .unwrap()
+            .expect("cannot obtain connection lock")
             .query_one(&sql, &[&hgnc])?
             .try_into()?;
 
@@ -282,9 +284,13 @@ impl ProviderInterface for Provider {
             WHERE tx_ac = $1 ORDER BY pro_ac DESC",
             self.config.db_schema
         );
-        if let Some(row) = (self.conn.lock().unwrap().query(&sql, &[&tx_ac])?)
-            .into_iter()
-            .next()
+        if let Some(row) = (self
+            .conn
+            .lock()
+            .expect("cannot obtain connection lock")
+            .query(&sql, &[&tx_ac])?)
+        .into_iter()
+        .next()
         {
             let result = Some(row.try_get("pro_ac")?);
             self.caches
@@ -313,7 +319,7 @@ impl ProviderInterface for Provider {
         let seq_id: String = self
             .conn
             .lock()
-            .unwrap()
+            .expect("cannot obtain connection lock")
             .query_one(&sql, &[&ac])?
             .try_get("seq_id")?;
 
@@ -324,7 +330,7 @@ impl ProviderInterface for Provider {
         let seq: String = self
             .conn
             .lock()
-            .unwrap()
+            .expect("cannot obtain connection lock")
             .query_one(&sql, &[&seq_id])?
             .try_get("seq")?;
 
@@ -346,7 +352,12 @@ impl ProviderInterface for Provider {
             self.config.db_schema
         );
         let mut result = Vec::new();
-        for row in self.conn.lock().unwrap().query(&sql, &[&md5])? {
+        for row in self
+            .conn
+            .lock()
+            .expect("cannot obtain connection lock")
+            .query(&sql, &[&md5])?
+        {
             result.push(row.get(0));
         }
         // Add sentinel sequence.
@@ -373,7 +384,12 @@ impl ProviderInterface for Provider {
             self.config.db_schema
         );
         let mut result = Vec::new();
-        for row in self.conn.lock().unwrap().query(&sql, &[&tx_ac])? {
+        for row in self
+            .conn
+            .lock()
+            .expect("cannot obtain connection lock")
+            .query(&sql, &[&tx_ac])?
+        {
             result.push(row.try_into()?);
         }
 
@@ -408,7 +424,7 @@ impl ProviderInterface for Provider {
         for row in self
             .conn
             .lock()
-            .unwrap()
+            .expect("cannot obtain connection lock")
             .query(&sql, &[&tx_ac, &alt_ac, &alt_aln_method])?
         {
             result.push(row.try_into()?);
@@ -440,7 +456,12 @@ impl ProviderInterface for Provider {
             self.config.db_schema, self.config.db_schema,
         );
         let mut result = Vec::new();
-        for row in self.conn.lock().unwrap().query(&sql, &[&gene])? {
+        for row in self
+            .conn
+            .lock()
+            .expect("cannot obtain connection lock")
+            .query(&sql, &[&gene])?
+        {
             result.push(row.try_into()?);
         }
 
@@ -482,7 +503,7 @@ impl ProviderInterface for Provider {
         for row in self
             .conn
             .lock()
-            .unwrap()
+            .expect("cannot obtain connection lock")
             .query(&sql, &[&alt_ac, &start_i, &end_i])?
         {
             let record: TxForRegionRecord = row.try_into()?;
@@ -512,7 +533,7 @@ impl ProviderInterface for Provider {
         let result: TxIdentityInfo = self
             .conn
             .lock()
-            .unwrap()
+            .expect("cannot obtain connection lock")
             .query_one(&sql, &[&tx_ac])?
             .try_into()?;
 
@@ -548,7 +569,7 @@ impl ProviderInterface for Provider {
         let result: TxInfoRecord = self
             .conn
             .lock()
-            .unwrap()
+            .expect("cannot obtain connection lock")
             .query_one(&sql, &[&tx_ac, &alt_ac, &alt_aln_method])?
             .try_into()?;
 
@@ -572,7 +593,12 @@ impl ProviderInterface for Provider {
             self.config.db_schema
         );
         let mut result = Vec::new();
-        for row in self.conn.lock().unwrap().query(&sql, &[&tx_ac])? {
+        for row in self
+            .conn
+            .lock()
+            .expect("cannot obtain connection lock")
+            .query(&sql, &[&tx_ac])?
+        {
             result.push(row.try_into()?);
         }
 

--- a/src/data/uta_sr.rs
+++ b/src/data/uta_sr.rs
@@ -51,7 +51,7 @@ impl Provider {
                 &config.seqrepo_path
             ))?
             .to_str()
-            .unwrap()
+            .expect("problem with path to string conversion")
             .to_string();
         let instance = seqrepo
             .file_name()
@@ -60,7 +60,7 @@ impl Provider {
                 &config.seqrepo_path
             ))?
             .to_str()
-            .unwrap()
+            .expect("problem with path to string conversion")
             .to_string();
 
         Ok(Self {
@@ -242,7 +242,7 @@ pub mod test_helpers {
                 &seqrepo_path
             ))?
             .to_str()
-            .unwrap()
+            .expect("problem with path to string conversion")
             .to_string();
         let instance = path_buf
             .file_name()
@@ -251,7 +251,7 @@ pub mod test_helpers {
                 &seqrepo_path
             ))?
             .to_str()
-            .unwrap()
+            .expect("problem with path to string conversion")
             .to_string();
         let seqrepo: Rc<dyn SeqRepoInterface> = Rc::new(CacheWritingSeqRepo::new(
             SeqRepo::new(path, &instance)?,

--- a/src/mapper/assembly.rs
+++ b/src/mapper/assembly.rs
@@ -312,7 +312,10 @@ impl Mapper {
         }
 
         if alt_acs.len() == 1 {
-            Ok(alt_acs.first().unwrap().to_owned())
+            Ok(alt_acs
+                .first()
+                .expect("should not happen; checked for one alt_ac above")
+                .to_owned())
         } else {
             // alt_acs.len() > 1
             // Perform sanity check on result if more than one contig is returned.
@@ -320,7 +323,7 @@ impl Mapper {
                 .iter()
                 .map(|ac| self.asm_map.get(ac))
                 .filter(|x| x.is_some())
-                .map(|x| x.unwrap().clone())
+                .map(|x| x.expect("should not happen; empty alt_ac").clone())
                 .collect::<Vec<_>>();
             alts.sort();
             if alts.join("") != "XY" {
@@ -360,7 +363,10 @@ impl Mapper {
                     alt_acs.len()
                 ))
             } else {
-                Ok(alt_acs.first().unwrap().to_owned())
+                Ok(alt_acs
+                    .first()
+                    .expect("should not happen; checked for exactly one alt_ac above")
+                    .to_owned())
             }
         }
     }
@@ -939,10 +945,10 @@ mod test {
 
             for row in rdr.records() {
                 let row = row?;
-                let disc_type = row.get(0).unwrap();
-                let loc_type = row.get(1).unwrap();
-                let variant = row.get(2).unwrap();
-                let expected = row.get(3).unwrap();
+                let disc_type = row.get(0).expect("problem in test TSV file");
+                let loc_type = row.get(1).expect("problem in test TSV file");
+                let variant = row.get(2).expect("problem in test TSV file");
+                let expected = row.get(3).expect("problem in test TSV file");
 
                 let var_n = HgvsVariant::from_str(variant)?;
                 let var_g = mapper.n_to_g(&var_n)?;

--- a/src/parser/impl_parse.rs
+++ b/src/parser/impl_parse.rs
@@ -893,22 +893,32 @@ mod test {
                 }
 
                 // setup input
-                let inputs = split_inputs(row.get(1).unwrap(), row.get(3).unwrap())?;
+                let inputs = split_inputs(
+                    row.get(1).expect("problem with test input file"),
+                    row.get(3).expect("problem with test input file"),
+                )?;
                 let expected_results = if row.get(4).is_some() && row.get(4) != Some("") {
-                    split_inputs(row.get(4).unwrap(), row.get(3).unwrap())?
+                    split_inputs(
+                        row.get(4).expect("problem with test input file"),
+                        row.get(3).expect("problem with test input file"),
+                    )?
                 } else {
                     inputs.clone()
                 };
-                let is_valid = row.get(2).unwrap().to_lowercase() == "true";
+                let is_valid = row
+                    .get(2)
+                    .expect("problem with test input file")
+                    .to_lowercase()
+                    == "true";
 
                 for (input, expected) in inputs.into_iter().zip(expected_results.into_iter()) {
-                    let func = row.get(0).unwrap();
+                    let func = row.get(0).expect("problem with test input file");
                     match func {
                         "accn" => {
                             let x = input.clone();
                             let res = all_consuming(Accession::parse)(&x);
                             if is_valid {
-                                let (r, acc) = res.unwrap();
+                                let (r, acc) = res.expect("problem with test input file");
                                 assert_eq!(r, "");
                                 assert_eq!(acc.as_str(), expected);
                             } else {

--- a/src/parser/parse_funcs.rs
+++ b/src/parser/parse_funcs.rs
@@ -204,7 +204,10 @@ pub mod protein_edit {
                     ProteinEdit::Fs {
                         alternative: alternative.map(str::to_owned),
                         terminal: Some(terminal.to_string()),
-                        length: UncertainLengthChange::Known(str::parse::<i32>(count).unwrap()),
+                        length: UncertainLengthChange::Known(
+                            str::parse::<i32>(count)
+                            .expect("should not happen; previous parsing should guarantee string with digits")
+                        ),
                     },
                 ))
             }
@@ -231,7 +234,9 @@ pub mod protein_edit {
             ProteinEdit::Ext {
                 aa_ext: aa_ext.map(str::to_owned),
                 ext_aa: ext_aa.map(str::to_owned),
-                change: UncertainLengthChange::Known(-str::parse::<i32>(offset).unwrap()),
+                change: UncertainLengthChange::Known(-str::parse::<i32>(offset).expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                )),
             },
         ))
     }
@@ -251,7 +256,7 @@ pub mod protein_edit {
                     change: if offset == "?" {
                         UncertainLengthChange::Unknown
                     } else {
-                        UncertainLengthChange::Known(str::parse::<i32>(offset).unwrap())
+                        UncertainLengthChange::Known(str::parse::<i32>(offset).expect("should not happen; previous parsing should guarantee string with digits"))
                     },
                 },
             ))
@@ -352,7 +357,8 @@ pub mod na_edit {
 
     pub fn del_num(input: &str) -> IResult<&str, NaEdit> {
         map(tuple((tag("del"), digit1)), |(_, count)| NaEdit::DelNum {
-            count: str::parse::<i32>(count).unwrap(),
+            count: str::parse::<i32>(count)
+                .expect("should not happen; previous parsing should guarantee string with digits"),
         })(input)
     }
 
@@ -374,7 +380,9 @@ pub mod na_edit {
         Ok((
             rest,
             NaEdit::NumAlt {
-                count: count.parse::<i32>().unwrap(),
+                count: count.parse::<i32>().expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ),
                 alternative: alternative.to_string(),
             },
         ))
@@ -405,7 +413,9 @@ pub mod na_edit {
         Ok((
             rest,
             NaEdit::InvNum {
-                count: count.parse::<i32>().unwrap(),
+                count: count.parse::<i32>().expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ),
             },
         ))
     }
@@ -440,8 +450,14 @@ pub mod cds_pos {
         Ok((
             rest,
             CdsPos {
-                base: str::parse::<i32>(base).unwrap(),
-                offset: offset.map(|offset| str::parse::<i32>(offset).unwrap()),
+                base: str::parse::<i32>(base).expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ),
+                offset: offset.map(|offset| {
+                    str::parse::<i32>(offset).expect(
+                        "should not happen; previous parsing should guarantee string with digits",
+                    )
+                }),
                 cds_from: CdsFrom::Start,
             },
         ))
@@ -454,8 +470,14 @@ pub mod cds_pos {
         Ok((
             rest,
             CdsPos {
-                base: str::parse::<i32>(base).unwrap(),
-                offset: offset.map(|offset| str::parse::<i32>(offset).unwrap()),
+                base: str::parse::<i32>(base).expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ),
+                offset: offset.map(|offset| {
+                    str::parse::<i32>(offset).expect(
+                        "should not happen; previous parsing should guarantee string with digits",
+                    )
+                }),
                 cds_from: CdsFrom::End,
             },
         ))
@@ -495,7 +517,9 @@ pub mod genome_pos {
             if value == "?" {
                 None
             } else {
-                Some(str::parse::<i32>(value).unwrap())
+                Some(str::parse::<i32>(value).expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ))
             }
         })(input)
     }
@@ -531,7 +555,9 @@ pub mod mt_pos {
             if value == "?" {
                 None
             } else {
-                Some(str::parse::<i32>(value).unwrap())
+                Some(str::parse::<i32>(value).expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ))
             }
         })(input)
     }
@@ -573,8 +599,14 @@ pub mod tx_pos {
         Ok((
             rest,
             TxPos {
-                base: str::parse::<i32>(base).unwrap(),
-                offset: offset.map(|offset| str::parse::<i32>(offset).unwrap()),
+                base: str::parse::<i32>(base).expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ),
+                offset: offset.map(|offset| {
+                    str::parse::<i32>(offset).expect(
+                        "should not happen; previous parsing should guarantee string with digits",
+                    )
+                }),
             },
         ))
     }
@@ -614,8 +646,14 @@ pub mod rna_pos {
         Ok((
             rest,
             RnaPos {
-                base: str::parse::<i32>(base).unwrap(),
-                offset: offset.map(|offset| str::parse::<i32>(offset).unwrap()),
+                base: str::parse::<i32>(base).expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ),
+                offset: offset.map(|offset| {
+                    str::parse::<i32>(offset).expect(
+                        "should not happen; previous parsing should guarantee string with digits",
+                    )
+                }),
             },
         ))
     }
@@ -657,7 +695,9 @@ pub mod prot_pos {
             rest,
             ProtPos {
                 aa: aa.to_string(),
-                number: str::parse::<i32>(number).unwrap(),
+                number: str::parse::<i32>(number).expect(
+                    "should not happen; previous parsing should guarantee string with digits",
+                ),
             },
         ))
     }

--- a/src/sequences.rs
+++ b/src/sequences.rs
@@ -58,7 +58,7 @@ pub fn trim_common_suffixes(reference: &str, alternative: &str) -> (usize, Strin
 /// Reverse complementing shortcut.
 pub fn revcomp(seq: &str) -> String {
     std::str::from_utf8(&bio::alphabets::dna::revcomp(seq.as_bytes()))
-        .unwrap()
+        .expect("invalid utf-8 encoding")
         .to_string()
 }
 
@@ -726,7 +726,8 @@ pub fn seq_md5(seq: &str, normalize: bool) -> Result<String, anyhow::Error> {
     hasher.update(seq);
     let hash = hasher.finalize();
     let mut buf = [0u8; 64];
-    let checksum = base16ct::lower::encode_str(&hash, &mut buf).unwrap();
+    let checksum =
+        base16ct::lower::encode_str(&hash, &mut buf).expect("cannot perform base16 encoding");
     Ok(checksum.to_owned())
 }
 

--- a/src/static_data/mod.rs
+++ b/src/static_data/mod.rs
@@ -27,8 +27,10 @@ impl Assembly {
         };
         let mut d = GzDecoder::new(payload);
         let mut grch37_json = String::new();
-        d.read_to_string(&mut grch37_json).unwrap();
-        serde_json::from_str::<AssemblyInfo>(&grch37_json).unwrap()
+        d.read_to_string(&mut grch37_json)
+            .expect("should not happen; invalid gzip in embedded data");
+        serde_json::from_str::<AssemblyInfo>(&grch37_json)
+            .expect("should not happen; invalid JSON in embedded data")
     }
 }
 


### PR DESCRIPTION
The remaining places are OK

```
$ rg -w unwrap
src/parser/ds.rs
32:    pub fn unwrap(self) -> T {
965:        assert_eq!(Mu::Certain(1).unwrap(), 1);
966:        assert_eq!(Mu::Uncertain(1).unwrap(), 1);
```