### PR TITLE
fix: only warn on combining RefAlt with whole gene deletion

### DIFF
--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -263,7 +263,10 @@ impl AltSeqBuilder {
                     log::warn!("Whole-gene inversion; consequence assumed to not affected protein product");
                     EditType::NotCds
                 },
-                _ => panic!("Invalid combination of whole gene variant location and NaEdit {na_edit:?}"),
+                NaEdit::RefAlt {.. } => {
+                    log::warn!("The whole-gene variant {} is not a clean deletion. Assuming whole gene deletion.", self.var_c);
+                    EditType::WholeGeneDeleted
+                }
             },
         };
 

--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -266,7 +266,8 @@ impl AltSeqBuilder {
                 NaEdit::RefAlt {.. } => {
                     log::warn!("The whole-gene variant {} is not a clean deletion. Assuming whole gene deletion.", self.var_c);
                     EditType::WholeGeneDeleted
-                }
+                },
+                _ => panic!("Invalid combination of whole gene variant location and NaEdit {na_edit:?}"),
             },
         };
 


### PR DESCRIPTION
Previously, there was a panic but that is not reasonable.